### PR TITLE
Add Github Actions for docker image releases

### DIFF
--- a/.github/workflows/push-develop.yml
+++ b/.github/workflows/push-develop.yml
@@ -1,0 +1,29 @@
+name: Publish Docker Image tagged as latest
+on:
+  push:
+    branches:
+      - 'develop'
+env:
+  DOCKERHUB_REPOSITORY: 'cennznet/ui'
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out from Git
+        uses: actions/checkout@master
+      - name: Publish Docker image
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: ${{env.DOCKERHUB_REPOSITORY}}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_PASSWORD }}
+          tags: 'latest'
+      - name: Update Docker Hub Description
+        uses: peter-evans/dockerhub-description@v2.1.0
+        env:
+          DOCKERHUB_REPOSITORY: ${{env.DOCKERHUB_REPOSITORY}}
+          DOCKERHUB_USERNAME: ${{ env.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ env.DOCKERHUB_PASSWORD }}
+          README_FILEPATH: ./cennznet/README.md

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -1,0 +1,29 @@
+name: Publish to DockerHub tagged as a version
+on:
+  push:
+    branches:
+      - 'release/**'
+env:
+  DOCKERHUB_REPOSITORY: 'cennznet/ui'
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out from Git
+        uses: actions/checkout@master
+      - name: Publish Docker image
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: ${{ env.DOCKERHUB_REPOSITORY }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_PASSWORD }}
+          tags: 'latest'
+      - name: Update Docker Hub Description
+        uses: peter-evans/dockerhub-description@v2.1.0
+        env:
+          DOCKERHUB_REPOSITORY: ${{env.DOCKERHUB_REPOSITORY}}
+          DOCKERHUB_USERNAME: ${{ env.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ env.DOCKERHUB_PASSWORD }}
+          README_FILEPATH: ./cennznet/README.md

--- a/cennznet/README.md
+++ b/cennznet/README.md
@@ -1,0 +1,16 @@
+# cennznet/ui
+
+## Get started
+
+- run `docker pull cenznet/cennznet:1.0.0-rc2` and `docker pull cennznet/ui:latest`;
+- run `docker run -p 9944:9944 -p 9933:9933 cenznet/cennznet:1.0.0-rc2 --dev --unsafe-ws-external --unsafe-rpc-external`;
+- run `docker run --rm -it --name cennznet-ui -p 3000:80 cennznet/ui:latest`;
+- browse `localhost:3000`;
+
+## Dependencies
+
+- cennznet/apps: (latest)
+  - cennznet/types: 1.0.0-beta.1
+  - cennznet: 1.0.0-rc2
+  - polkadot/apps: 0.40.0-beta.45
+  - polkadot/api.js: 1.1.1

--- a/cennznet/docs/DEVELOPMENT.md
+++ b/cennznet/docs/DEVELOPMENT.md
@@ -1,0 +1,18 @@
+# cennznet/ui development
+
+## Publish
+
+### Docker image with a tag labbeld as latest
+
+- Whenever a PR is merged into `develop` branch, a docker image with `latest` tag should be generated;
+
+### Docker image with a tag labbeled as a version number
+
+- Create a new branch from `develop` branch, named as `release/1.0.0` for instance;
+- `git push --set-upstream origin 1.0.0`;
+- `git tag -a 1.0.0`;
+- `git push --tags -f`;
+- At this point a Docker image with a tag as `1.0.0` should be generated;
+- Create a PR to merge `release/1.0.0` branch to `develop`;
+- Once the PR is merged, a Docker image with a tag as `latest` should be generated;
+- Go to DockerHub, ensure the docker image can be pulled as `cennznet/ui:latest` and `cennznet/ui:release-1.0.0`;


### PR DESCRIPTION
credentials need to be set up before the PR is merged to get Docker release work;

I am using `cennznet/apps` for now, could change it later once we come up with a new name;

Once this PR is merged, I am going to test pulling down docker images to local.