### PR TITLE
Styled theming

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "bracketSpacing": true,
+  "jsxSingleQuote": true,
+  "printWidth": 80,
+  "singleQuote": true,
+  "trailingComma": "none"
+}

--- a/package.json
+++ b/package.json
@@ -66,5 +66,9 @@
     "webpack": "^4.41.6",
     "webpack-cli": "^3.3.11",
     "webpack-plugin-serve": "^0.12.1"
+  },
+  "dependencies": {
+    "merge-options": "^2.0.0",
+    "polished": "^3.4.4"
   }
 }

--- a/packages/apps/src/SideBar/Item.tsx
+++ b/packages/apps/src/SideBar/Item.tsx
@@ -7,13 +7,14 @@ import { Route } from '@polkadot/apps-routing/types';
 import { AccountId } from '@polkadot/types/interfaces';
 
 import React, { useEffect, useState } from 'react';
-import { NavLink } from 'react-router-dom';
+// import { NavLink } from 'react-router-dom';
 import { ApiPromise } from '@polkadot/api';
-import { Badge, Icon, Menu, Tooltip } from '@polkadot/react-components';
+import { Badge, Icon, Tooltip } from '@polkadot/react-components';
 import { useAccounts, useApi, useCall } from '@polkadot/react-hooks';
 import { isFunction } from '@polkadot/util';
 
 import { useTranslation } from '../translate';
+import { SideBarItem, SideBarItemLink, SideBarItemNavLink } from './SideBarItem';
 
 const DUMMY_COUNTER = (): number => 0;
 
@@ -115,23 +116,20 @@ export default function Item ({ route, isCollapsed, onClick }: Props): React.Rea
   );
 
   return (
-    <Menu.Item className='apps--SideBar-Item'>
+    <SideBarItem>
       {Modal
         ? (
-          <a
-            className='apps--SideBar-Item-NavLink'
+          <SideBarItemLink
             data-for={`nav-${name}`}
             data-tip
             data-tip-disable={!isCollapsed}
             onClick={onClick}
           >
             {body}
-          </a>
+          </SideBarItemLink>
         )
         : (
-          <NavLink
-            activeClassName='apps--SideBar-Item-NavLink-active'
-            className='apps--SideBar-Item-NavLink'
+          <SideBarItemNavLink
             data-for={`nav-${name}`}
             data-tip
             data-tip-disable={!isCollapsed}
@@ -139,9 +137,9 @@ export default function Item ({ route, isCollapsed, onClick }: Props): React.Rea
             to={`/${name}`}
           >
             {body}
-          </NavLink>
+          </SideBarItemNavLink>
         )
       }
-    </Menu.Item>
+    </SideBarItem>
   );
 }

--- a/packages/apps/src/SideBar/SideBar.tsx
+++ b/packages/apps/src/SideBar/SideBar.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import { ThemeProps } from '../../../../styled-theming/types';
+
+const defaultThemeStyle = (p: ThemeProps): object => {
+  const { colors } = p.theme;
+
+  return {
+    background: colors.N900
+  };
+};
+
+const computedThemeStyle = (p: ThemeProps): any => p.theme.utils.createThemeStyle(p, defaultThemeStyle);
+
+const SideBar = styled.div.attrs({
+  className: 'apps--SideBar'
+})`
+  align-items: center;
+  background: ${(p: any): string => computedThemeStyle(p).background};
+  box-sizing: border-box;
+  display: flex;
+  flex-flow: column;
+  height: auto;
+  position: relative;
+  transition: left 0.3s linear;
+  width: 100%;
+`;
+
+SideBar.defaultProps = {
+  key: 'AppSideBar'
+};
+
+export default SideBar;

--- a/packages/apps/src/SideBar/SideBarItem.tsx
+++ b/packages/apps/src/SideBar/SideBarItem.tsx
@@ -1,0 +1,85 @@
+import { Menu } from '@polkadot/react-components';
+import { NavLink } from 'react-router-dom';
+
+import styled from 'styled-components';
+
+const SideBarItem = styled(Menu.Item).attrs({
+  className: 'apps--SideBar-Item'
+})`
+  align-self: flex-end;
+  flex-grow: 0;
+  padding: 0 !important;
+  position: relative;
+  width: inherit;
+
+  .text {
+    padding-left: 0.5rem;
+  }
+
+  .ui--Badge {
+    margin: 0;
+    position: absolute;
+    right: 0.5rem;
+    top: 0.55rem;
+    z-index: 1;
+  }
+
+  .collapsed & {
+    margin-left: 5px;
+
+      .text {
+        display: none;
+      }
+  }
+`;
+
+const SideBarItemLink = styled.a.attrs({
+  className: 'apps--SideBar-Item-NavLink'
+})`
+  color: #f5f5f5;
+  display: block;
+  padding: 0.75em 0.75em;
+  white-space: nowrap;
+
+  &:hover {
+    background: #5f5f5f;
+    border-radius: 0.28571429rem 0 0 0.28571429rem;
+    color: #eee;
+    margin-right: 0.25rem;
+  }
+`;
+
+const SideBarItemNavLink = styled(NavLink).attrs({
+  className: 'apps--SideBar-Item-NavLink',
+  activeClassName: 'apps--SideBar-Item-NavLink-active ui--highlight--border'
+})`
+  color: #f5f5f5;
+  display: block;
+  padding: 0.75em 0.75em;
+  white-space: nowrap;
+
+  &:hover {
+    background: #5f5f5f;
+    border-radius: 0.28571429rem 0 0 0.28571429rem;
+    color: #eee;
+    margin-right: 0.25rem;
+  }
+
+  &.apps--SideBar-Item-NavLink-active {
+    background: #fafafa;
+    border-radius: 0.28571429rem 0 0 0.28571429rem;
+    color: #3f3f3f;
+
+    &:hover {
+      background: #fafafa;
+      color: #3f3f3f;
+      margin-right: 0;
+    }
+  }
+`;
+
+export {
+  SideBarItem,
+  SideBarItemNavLink,
+  SideBarItemLink
+};

--- a/packages/apps/src/SideBar/index.tsx
+++ b/packages/apps/src/SideBar/index.tsx
@@ -13,11 +13,13 @@ import { Button, ChainImg, Icon, Menu, media } from '@polkadot/react-components'
 import { useCall, useApi } from '@polkadot/react-hooks';
 import { classes } from '@polkadot/react-components/util';
 import { BestNumber, Chain } from '@polkadot/react-query';
-
 import { useTranslation } from '../translate';
 import Item from './Item';
 import NodeInfo from './NodeInfo';
 import NetworkModal from '../modals/Network';
+
+import SideBar from './SideBar';
+import { SideBarItem, SideBarItemLink } from './SideBarItem';
 
 interface Props {
   className?: string;
@@ -28,7 +30,7 @@ interface Props {
   toggleMenu: () => void;
 }
 
-function SideBar ({ className, collapse, handleResize, isCollapsed, isMenuOpen, toggleMenu }: Props): React.ReactElement<Props> {
+function SideBarContainer ({ className, collapse, handleResize, isCollapsed, isMenuOpen, toggleMenu }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
   const runtimeVersion = useCall<RuntimeVersion>(api.rpc.state.subscribeRuntimeVersion, []);
@@ -69,7 +71,7 @@ function SideBar ({ className, collapse, handleResize, isCollapsed, isMenuOpen, 
       {modals.network && (
         <NetworkModal onClose={_toggleModal('network')}/>
       )}
-      <div className='apps--SideBar'>
+      <SideBar>
         <Menu
           secondary
           vertical
@@ -127,26 +129,24 @@ function SideBar ({ className, collapse, handleResize, isCollapsed, isMenuOpen, 
                   )
                   : null
               ))}
-              <Menu.Item className='apps--SideBar-Item'>
-                <a
-                  className='apps--SideBar-Item-NavLink'
+              <SideBarItem>
+                <SideBarItemLink
                   href='https://github.com/polkadot-js/apps'
                   rel='noopener noreferrer'
                   target='_blank'
                 >
                   <Icon name='github' /><span className='text'>{t('GitHub')}</span>
-                </a>
-              </Menu.Item>
-              <Menu.Item className='apps--SideBar-Item'>
-                <a
-                  className='apps--SideBar-Item-NavLink'
+                </SideBarItemLink>
+              </SideBarItem>
+              <SideBarItem>
+                <SideBarItemLink
                   href='https://wiki.polkadot.network'
                   rel='noopener noreferrer'
                   target='_blank'
                 >
                   <Icon name='book' /><span className='text'>{t('Wiki')}</span>
-                </a>
-              </Menu.Item>
+                </SideBarItemLink>
+              </SideBarItem>
             </details>
             <Menu.Divider hidden />
             {
@@ -173,12 +173,12 @@ function SideBar ({ className, collapse, handleResize, isCollapsed, isMenuOpen, 
             onClick={collapse}
           />
         </Responsive>
-      </div>
+      </SideBar>
     </Responsive>
   );
 }
 
-export default styled(SideBar)`
+export default styled(SideBarContainer)`
 .apps--SideBar-Advanced {
     margin-top: 1rem;
     color: #f5f5f5;
@@ -197,14 +197,14 @@ export default styled(SideBar)`
   }
 
   .apps--SideBar {
-    align-items: center;
+    /* align-items: center;
     background: #4f4f4f;
     display: flex;
     flex-flow: column;
     height: auto;
     position: relative;
     transition: left 0.3s linear;
-    width: 100%;
+    width: 100%; */
 
     .ui.vertical.menu {
       display: flex;
@@ -231,10 +231,10 @@ export default styled(SideBar)`
     }
 
     .apps--SideBar-Item {
-      align-self: flex-end;
+      /* align-self: flex-end;
       flex-grow: 0;
       padding: 0 !important;
-      width: inherit;
+      width: inherit; */
 
       .text {
         padding-left: 0.5rem;

--- a/packages/apps/src/index.tsx
+++ b/packages/apps/src/index.tsx
@@ -17,10 +17,11 @@ import { BlockAuthors, Events } from '@polkadot/react-query';
 import settings from '@polkadot/ui-settings';
 
 import Apps from './Apps';
+import theme from '../../../styled-theming';
 
 const rootId = 'root';
 const rootElement = document.getElementById(rootId);
-const theme = { theme: settings.uiTheme };
+// const theme = { theme: settings.uiTheme };
 
 if (!rootElement) {
   throw new Error(`Unable to find element with id '${rootId}'`);

--- a/packages/react-components/src/styles/theme.ts
+++ b/packages/react-components/src/styles/theme.ts
@@ -17,16 +17,16 @@ const colorBtnPrimary = '#2e86ab';
 const colorBtnText = '#f9f9f9';
 
 export default css`
-  .theme--default {
-    a {
+  a {
+    color: ${colorBtnPrimary};
+
+    &:hover,
+    a:visited {
       color: ${colorBtnPrimary};
-
-      &:hover,
-      a:visited {
-        color: ${colorBtnPrimary};
-      }
     }
+  }
 
+  .theme--default {
     .ui.button,
     .ui.buttons .button {
       background-color: ${colorBtnDefault};

--- a/styled-theming/index.ts
+++ b/styled-theming/index.ts
@@ -1,0 +1,9 @@
+// import * as lightTheme from './light';
+import * as darkTheme from './themes/dark';
+
+const currentTheme = darkTheme;
+
+const { default: theme, colors, utils } = currentTheme;
+
+export { colors, utils };
+export default theme;

--- a/styled-theming/themes/dark/colors.ts
+++ b/styled-theming/themes/dark/colors.ts
@@ -1,0 +1,102 @@
+// Copyright 2019 Atlassian Pty Ltd
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license.
+
+// Ref: https://bitbucket.org/atlassian/atlaskit-mk-2/src/master/packages/core/theme/src/colors.ts
+
+import { rgba } from 'polished';
+
+/** Nuetral */
+export const N0 = '#FFFFFF';
+export const N50 = '#F8F9F9';
+export const N100 = '#EBECED';
+export const N200 = '#D0D3D5';
+export const N300 = '#B5BABD';
+export const N400 = '#9AA0A5';
+export const N500 = '#7F878D';
+export const N600 = '#666D73';
+export const N700 = '#4E5458';
+export const N800 = '#363A3D';
+export const N900 = '#1E2022';
+export const N1000 = '#000000';
+
+/** Red */
+export const R100 = '#FBD2D3';
+export const R200 = '#F7A3A6';
+export const R300 = '#F37479';
+export const R400 = '#EF454B';
+export const R500 = '#EB161E';
+export const R600 = '#BE1017';
+export const R700 = '#8F0C11';
+export const R800 = '#60080C';
+export const R900 = '#310406';
+
+/** Yellow */
+export const Y100 = '#FFF3CC';
+export const Y200 = '#FFE899';
+export const Y300 = '#FFDC66';
+export const Y400 = '#FFD133';
+export const Y500 = '#FFC500';
+export const Y600 = '#CC9E00';
+export const Y700 = '#997600';
+export const Y800 = '#664F00';
+export const Y900 = '#332700';
+
+/** Green */
+export const G100 = '#CDECD6';
+export const G200 = '#A9DDB8';
+export const G300 = '#84CF9A';
+export const G400 = '#5FC17C';
+export const G500 = '#42AB61';
+export const G600 = '#34864C';
+export const G700 = '#266137';
+export const G800 = '#173D22';
+export const G900 = '#09180D';
+
+/** Blue */
+export const B100 = '#C8E6FF';
+export const B200 = '#95CEFF';
+export const B300 = '#63B6FE';
+export const B400 = '#309FFE';
+export const B500 = '#0187FA';
+export const B600 = '#016CC7';
+export const B700 = '#015094';
+export const B800 = '#003562';
+export const B900 = '#00192F';
+
+/** Violet */
+export const V100 = '#725EFF';
+export const V200 = '#725EFF';
+export const V300 = '#725EFF';
+export const V400 = '#725EFF';
+export const V500 = '#1130FF';
+export const V600 = '#0000CA';
+export const V700 = '#08187F';
+export const V800 = '#040C40';
+export const V900 = '#020835';
+
+export const brandPrimary = rgba(17, 48, 255, 0.9);
+export const brandSecondary = Y400;
+
+export const primary = rgba(17, 48, 255, 0.9);
+export const secondary = V800;
+export const background = V900;
+export const success = G400;
+export const warning = Y400;
+export const danger = R400;
+export const info = N100;
+export const nuetral = N500;
+export const border = rgba(255, 255, 255, 0.3);
+export const borderLight = N100;
+export const text = N0;
+export const textMuted = rgba(255, 255, 255, 0.7);
+export const textHover = N200;
+export const link = B500;
+export const linkHover = B600;
+/**
+ * NOTICE: this file only contains basic color defination of basic elements like border,
+ * text, link, etc.
+ *
+ * For application/ components resuable colors, theme/index.js is the file to be considered.
+ *
+ * */

--- a/styled-theming/themes/dark/components.ts
+++ b/styled-theming/themes/dark/components.ts
@@ -1,0 +1,10 @@
+/**
+ * Similar idea with https://react-theming.github.io/create-mui-theme/
+ */
+const configComponentStyle = (colors: any): object | {} => ({
+  // AppSideBar: {
+  //   background: colors.N900
+  // }
+});
+
+export default configComponentStyle;

--- a/styled-theming/themes/dark/index.ts
+++ b/styled-theming/themes/dark/index.ts
@@ -1,0 +1,24 @@
+import * as colors from './colors';
+import * as utils from '../../utils';
+import components from './components';
+
+const theme = {
+  /* essential */
+  colors: { ...colors },
+  components: components(colors),
+  utils: { ...utils },
+  /* optional */
+  borderRadius: '3px',
+  fontSize: '14px',
+  fontSizeLg: '1rem',
+  fontSizeSm: '12px',
+  zIndex: {
+    overlay: 20,
+    above: 10,
+    bump: 1,
+    below: -1
+  }
+};
+
+export { colors, utils };
+export default theme;

--- a/styled-theming/types.ts
+++ b/styled-theming/types.ts
@@ -1,0 +1,12 @@
+export type StyledTheme = {
+  colors: any;
+  components: object;
+  utils: any;
+};
+
+export type ThemeProps = {
+  theme: StyledTheme;
+  key?: string;
+  themeKey?: string;
+  themeStyle?: object;
+};

--- a/styled-theming/utils.ts
+++ b/styled-theming/utils.ts
@@ -1,0 +1,13 @@
+// @ts-nocheck
+
+import deepMerge from 'merge-options';
+import { ThemeProps } from './types';
+
+export const createThemeStyle = (themeProps: ThemeProps, defaultThemeStyle: (arg0: ThemeProps) => object): ThemeProps => {
+  return deepMerge(
+    {},
+    defaultThemeStyle(themeProps),
+    themeProps.themeStyle,
+    themeProps.theme.components[themeProps.themeKey || themeProps.key]
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,7 +939,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.8.3":
+"@babel/runtime@^7.6.3", "@babel/runtime@^7.8.3":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
   integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
@@ -9103,6 +9103,11 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
+is-plain-obj@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -10705,6 +10710,13 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
+merge-options@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-2.0.0.tgz#36ca5038badfc3974dbde5e58ba89d3df80882c3"
+  integrity sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==
+  dependencies:
+    is-plain-obj "^2.0.0"
+
 merge-source-map@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
@@ -12203,6 +12215,13 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+
+polished@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.4.4.tgz#ac8cd6e704887398f3b802718f9d389b9ea4307b"
+  integrity sha512-x9PKeExyI9AhWrJP3Q57I1k7GInujjiVBJMPFmycj9hX1yCOo/X9eu9eZwxgOziiXge3WbFQ5XOmkzunOntBSA==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
 
 popper.js@^1.14.4:
   version "1.16.1"


### PR DESCRIPTION
Applied theming in favor of `styled-components` which is largely used in `polkadot/apps`; and refactored SideBar in `cennznet/apps` in a bit to apply Centrality styles.

More details on how theming works refers to [here](https://centrality-react-components-demo.netlify.com/#section-how-theming-works)

demo of applying `colors.R900` as background in sidebar
<img width="280" alt="Screen Shot 2020-03-17 at 11 26 29 AM" src="https://user-images.githubusercontent.com/1513326/76805317-5e280500-6843-11ea-96a6-99fa229b9ec5.png">
