### PR TITLE
Prepopulating GA asset page with CENNZnet assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@polkadot/util": "^2.3.1",
     "@polkadot/util-crypto": "^2.4.1",
     "babel-core": "^7.0.0-bridge.0",
-    "typescript": "^3.7.5"
+    "typescript": "^3.8.1"
   },
   "scripts": {
     "analyze": "yarn run build && cd packages/apps && yarn run source-map-explorer build/main.*.js",

--- a/packages/app-generic-asset/package.json
+++ b/packages/app-generic-asset/package.json
@@ -12,6 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.8.4",
+    "@cennznet/crml-generic-asset": "1.0.0-beta.1",
     "@polkadot/react-components": "0.40.0-beta.45"
   }
 }

--- a/packages/app-generic-asset/src/asset-util.ts
+++ b/packages/app-generic-asset/src/asset-util.ts
@@ -1,0 +1,10 @@
+import { assetRegistry } from '@cennznet/crml-generic-asset';
+
+const assets = assetRegistry.reserveAssets();
+export const reservedAssets = assets.reduce((acc: { [index: string]: string }, asset) => {
+  const key = asset.id;
+  if (!asset.symbol.endsWith('-T')) {
+    acc[key] = asset.symbol;
+  }
+  return acc;
+}, {});

--- a/packages/app-generic-asset/src/assetsRegistry.tsx
+++ b/packages/app-generic-asset/src/assetsRegistry.tsx
@@ -3,6 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { BehaviorSubject } from 'rxjs';
+import { reservedAssets } from '@polkadot/app-generic-asset/asset-util';
 
 const ASSETS_KEY = 'polkadot-app-generic-asset-assets';
 
@@ -14,6 +15,8 @@ try {
   const storedAsset = localStorage.getItem(ASSETS_KEY);
   if (storedAsset) {
     initalAssets = JSON.parse(storedAsset);
+  } else {
+    initalAssets = reservedAssets;
   }
 } catch (e) {
   // ignore error

--- a/packages/app-generic-asset/src/index.tsx
+++ b/packages/app-generic-asset/src/index.tsx
@@ -18,11 +18,11 @@ interface Props extends AppProps, BareProps {}
 export default function AssetApp ({ basePath }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const items = useMemo(() => [
-    {
-      isRoot: true,
-      name: 'assets',
-      text: t('Assets')
-    },
+    // {
+    //   isRoot: true,
+    //   name: 'assets',
+    //   text: t('Assets')
+    // },
     {
       name: 'transfer',
       text: t('Transfer')

--- a/packages/react-params/src/Param/File.tsx
+++ b/packages/react-params/src/Param/File.tsx
@@ -15,7 +15,7 @@ interface Props extends BareProps {
   isError?: boolean;
   label?: React.ReactNode;
   onChange?: (contents: Uint8Array) => void;
-  placeholder?: string;
+  placeholder?: string | any;
   withLabel?: boolean;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15379,10 +15379,10 @@ typedoc@^0.16.9:
     typedoc-default-themes "^0.7.2"
     typescript "3.7.x"
 
-typescript@3.7.x, typescript@^2.9.2, typescript@^3.0.3, typescript@^3.6.4, typescript@^3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@3.7.x, typescript@^2.9.2, typescript@^3.0.3, typescript@^3.6.4, typescript@^3.7.5, typescript@^3.8.1:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 u2f-api@0.2.7:
   version "0.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,6 +939,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.8.3":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
+  integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.7.4", "@babel/template@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.3.tgz#e02ad04fe262a657809327f578056ca15fd4d1b8"
@@ -977,7 +984,51 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cennznet/types@1.0.0-beta.1":
+"@cennznet/api@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@cennznet/api/-/api-1.0.0-beta.1.tgz#b4438f5b5caa789dd6bb47c67a839788b4cbf7db"
+  integrity sha512-AGqGzoJZQi2nSBZBtuKfMZesYMATpISHecBbnG8x8WUMVhWiWfppCX14wJYZnljqK1Fk77QCsFXMKqwfb6QBNQ==
+  dependencies:
+    "@cennznet/crml-attestation" "^1.0.0-beta.1"
+    "@cennznet/crml-cennzx-spot" "^1.0.0-beta.1"
+    "@cennznet/crml-generic-asset" "^1.0.0-beta.1"
+    "@cennznet/types" "^1.0.0-beta.1"
+    "@polkadot/api" "^1.1.1"
+    "@polkadot/metadata" "1.1.1"
+    "@polkadot/rpc-core" "^1.1.1"
+    "@polkadot/rpc-provider" "^1.1.1"
+    "@polkadot/types" "^1.1.1"
+    eventemitter3 "^4.0.0"
+
+"@cennznet/crml-attestation@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@cennznet/crml-attestation/-/crml-attestation-1.0.0-beta.1.tgz#c140986b48a2cab2336f75eb5b785197bd0c4b02"
+  integrity sha512-5RV9wjYMK+Ou1rui1dPqTDvh8uNBNf2LrL1et6S0eQ7zZbEu7Rj8tiz4p086KDMaAFNHvL9HAJmVXK2yOOLl4A==
+  dependencies:
+    "@cennznet/api" "^1.0.0-beta.1"
+    "@cennznet/types" "^1.0.0-beta.1"
+    "@cennznet/util" "^1.0.0-beta.1"
+
+"@cennznet/crml-cennzx-spot@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@cennznet/crml-cennzx-spot/-/crml-cennzx-spot-1.0.0-beta.1.tgz#0f77d983102e1b4bd7a3c4c432712091e0cb33ce"
+  integrity sha512-GW/7dxF+OrdkSj6UgYma00Oqfrlugnb6oh1AiPj/iCFLblne4o9t4n2FQ+mSABQsuu00+7gJwdXY9xR+Q2D1EA==
+  dependencies:
+    "@cennznet/api" "^1.0.0-beta.1"
+    "@cennznet/crml-generic-asset" "^1.0.0-beta.1"
+    "@cennznet/types" "^1.0.0-beta.1"
+    "@cennznet/util" "^1.0.0-beta.1"
+
+"@cennznet/crml-generic-asset@1.0.0-beta.1", "@cennznet/crml-generic-asset@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@cennznet/crml-generic-asset/-/crml-generic-asset-1.0.0-beta.1.tgz#29fe2df201089b8aa461c124f8891f91cf7ac1c7"
+  integrity sha512-m23Zg2mqXdaEVvfZKsaK1lWoTb047E4ifOVYlDEmfEwgWIwez8SQJocqM0Iluxl2gGKU/EpPBpsJ7w4Aj6Yu1A==
+  dependencies:
+    "@cennznet/api" "^1.0.0-beta.1"
+    "@cennznet/types" "^1.0.0-beta.1"
+    "@cennznet/util" "^1.0.0-beta.1"
+
+"@cennznet/types@1.0.0-beta.1", "@cennznet/types@^1.0.0-beta.1":
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/@cennznet/types/-/types-1.0.0-beta.1.tgz#90177e02ecc7c748a5e5a5c557da18ba4b8d58b0"
   integrity sha512-FM2eTsM8e+FTPQIhdwP+u2psJpdo3ybuBD+XzVSi71HIigGZmW+59itE77eisf7rzhA+bLTuakM6O5QnKmadzw==
@@ -2352,6 +2403,15 @@
     "@polkadot/types" "1.4.0-beta.16"
     "@polkadot/util" "^2.4.1"
 
+"@polkadot/jsonrpc@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-1.6.2.tgz#57c057b9d649782753621afa0390ed5a86b9b480"
+  integrity sha512-hYzyT0QsUzLBb0JUtzAfp0XPKuSJnd/RnpOpVf5yZ9lk1Z+sqpe9z1LsutAPWZtUhFNtUhUfxDOSrGWu28XKhg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@polkadot/types" "1.6.2"
+    "@polkadot/util" "^2.6.2"
+
 "@polkadot/jsonrpc@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-1.3.1.tgz#00436699e06dbacf67225e881c52e38735b7e797"
@@ -2370,6 +2430,16 @@
     "@polkadot/util" "^2.3.1"
     "@polkadot/util-crypto" "^2.3.1"
 
+"@polkadot/metadata@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.1.1.tgz#1c7d2e026791d5e3453304065646711da74a0025"
+  integrity sha512-NjBngIHy5JsrMI6iyDT8qMx25pSwXaNnRrgHiP3oNaoMadoCfqRRSsC3JCqIhHQva6WZ/JfFxorRyH1sTAKbZg==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    "@polkadot/types" "^1.1.1"
+    "@polkadot/util" "^2.2.1"
+    "@polkadot/util-crypto" "^2.2.1"
+
 "@polkadot/metadata@1.4.0-beta.16":
   version "1.4.0-beta.16"
   resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.4.0-beta.16.tgz#798e83474df49c289292f7e3e3678ce8c3715a57"
@@ -2379,6 +2449,17 @@
     "@polkadot/types" "1.4.0-beta.16"
     "@polkadot/util" "^2.4.1"
     "@polkadot/util-crypto" "^2.4.1"
+    bn.js "^5.1.1"
+
+"@polkadot/metadata@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.6.2.tgz#38ef3c95209485bfcc9da9258f53e4c3da9510a3"
+  integrity sha512-iFolXhI83E8s1Ac2RWV0ws2NL41phZSL2roscSFWsi4wUITg8h71o7W6Gp5olWeXvENraCga2Uei4+1AvvFsQg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@polkadot/types" "1.6.2"
+    "@polkadot/util" "^2.6.2"
+    "@polkadot/util-crypto" "^2.6.2"
     bn.js "^5.1.1"
 
 "@polkadot/metadata@^1.3.1":
@@ -2428,6 +2509,20 @@
     memoizee "^0.4.14"
     rxjs "^6.5.4"
 
+"@polkadot/rpc-core@^1.1.1":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.6.2.tgz#4ea68dcfd29ea749d92a968abec3ba738aae4774"
+  integrity sha512-GZeXwx3wzpS4TPEE9SjqaawmMGmB8lrvOysS1F8trRBQ278H6xt/oGS9PiATZ0Tkv4pdGPMZvStQFYaIK31Rcg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@polkadot/jsonrpc" "1.6.2"
+    "@polkadot/metadata" "1.6.2"
+    "@polkadot/rpc-provider" "1.6.2"
+    "@polkadot/types" "1.6.2"
+    "@polkadot/util" "^2.6.2"
+    memoizee "^0.4.14"
+    rxjs "^6.5.4"
+
 "@polkadot/rpc-core@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.3.1.tgz#0957311f1f5fde905ca4d1311881af6270dcdefe"
@@ -2458,6 +2553,22 @@
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.31"
 
+"@polkadot/rpc-provider@1.6.2", "@polkadot/rpc-provider@^1.1.1":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.6.2.tgz#c8df4dcb4cf6931d691aa02952ac5c9dc68cac6e"
+  integrity sha512-PJF7124SAOiTLI+ySFkX6BxgPzU8cWrlitvSKHW/ClQHvmF0A8qR2qILiPKwY9rMYbgHbLzJqOyt3JrVPuCVxA==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@polkadot/jsonrpc" "1.6.2"
+    "@polkadot/metadata" "1.6.2"
+    "@polkadot/types" "1.6.2"
+    "@polkadot/util" "^2.6.2"
+    "@polkadot/util-crypto" "^2.6.2"
+    bn.js "^5.1.1"
+    eventemitter3 "^4.0.0"
+    isomorphic-fetch "^2.2.1"
+    websocket "^1.0.31"
+
 "@polkadot/rpc-provider@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.3.1.tgz#d35d2ad56bc777a39a453ba46d4e67b0052adb9d"
@@ -2481,7 +2592,7 @@
   dependencies:
     "@types/chrome" "^0.0.95"
 
-"@polkadot/types@1.4.0-beta.16", "@polkadot/types@^1.1.1", "@polkadot/types@^1.3.1":
+"@polkadot/types@1.4.0-beta.16", "@polkadot/types@1.6.2", "@polkadot/types@^1.1.1", "@polkadot/types@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.3.1.tgz#849050c11f0cbe119822e601a4500d2d2822fbc8"
   integrity sha512-BJOVE9rjeBOCCcl8Z2DlBXooavipovQwPs4HDMGykdypYmjKIpr1iEVBKWhDspANfNUi7PntfoLGNvsga0PSiw==
@@ -2533,7 +2644,7 @@
     "@babel/runtime" "^7.8.4"
     color "^3.1.2"
 
-"@polkadot/util-crypto@^2.3.1", "@polkadot/util-crypto@^2.4.1":
+"@polkadot/util-crypto@^2.2.1", "@polkadot/util-crypto@^2.3.1", "@polkadot/util-crypto@^2.4.1", "@polkadot/util-crypto@^2.6.2":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-2.4.1.tgz#f02e4dca225882c7f1a7762bc416530567c4803c"
   integrity sha512-5mPuRhpvYXeLqqGEqOtJqp+lZCr1Z2NIxIKgabaFfrp1malbgWhKDnafkAg7kwL3BrRQbOge0vgK6VmDiuXljQ==
@@ -2552,7 +2663,7 @@
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@^2.3.1", "@polkadot/util@^2.4.1":
+"@polkadot/util@^2.2.1", "@polkadot/util@^2.3.1", "@polkadot/util@^2.4.1", "@polkadot/util@^2.6.2":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-2.5.1.tgz#8b4be9f7418a2872f6ccb1a0d18e426b4e8779a9"
   integrity sha512-MVQPyxkhfERvV1uGyne0b7iekX9h7v892144bNB5VYZ7C2rTuJ5XpaWgx0V9DANeaEv+cqfjeW+8ngYQwYhQKw==
@@ -13186,6 +13297,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
With this PR,  the Generic Assets Page will be pre-populated with all core GenericAsset IDs and the friendly name e.g. 16000 => CENNZ
This is to reduce friction and confusion for users so they can easily transfer core assets without needing to fill in this information.
Also we removed the 'Asset' tab from the 'Generic Asset's' app, as we don't allow registration for now.

Files added ~
asset-util - file created to have all utility functions, here we get GA reserved assets and filter all test assets.
Files/part removed ~ Removed asset tab from Generic Asset app, now we only have transfer. The code is commented in (packages/app-generic-asset/src/index.tsx) file.
Files modified ~
added "@cennznet/crml-generic-asset": "1.0.0-beta.1", to get Generic Asset reserved assets in package.json
Modified assetRegistry to take initial value from the GA reserved assets.

With this PR, we are able to add an asset we would like for testing, have attached gif to show the same.
Also when your local storage already has some values cache, you might need to remove it from browser, go to Application and local storage, search for key 'polkadot-app-generic-asset-assets' and delete. Added in the gif as well.. Else you won't get the new setting reflected.
![Asset Dropdown](https://user-images.githubusercontent.com/29415595/76805386-86afff00-6843-11ea-9135-7195119f90da.gif)

